### PR TITLE
Add Linux support (with Wine).

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
 
 ### 平台依赖
 
-本项目支持 Windows Linux 子系统（WSL）与 macOS 平台。请先确保以下依赖已安装：
+本项目支持 Windows Linux 子系统（WSL）、Linux x86-64（带有 Wine）与 macOS 平台。请先确保以下依赖已安装：
 
 * Python 3.8 及以上
 * PyPI 包管理（`pip`）
@@ -96,12 +96,12 @@
 * `pip install skia-pathops`: [skia-pathops](https://github.com/fonttools/skia-pathops)
 * `pip install fonttools`: [FontTools](https://github.com/fonttools/fonttools)
 * `pip install toml`: [TOML](https://github.com/toml-lang/toml)
-* `sudo apt install zip`（仅供 WSL，macOS 已自带）
-* `sudo apt install rename`（仅供 WSL，macOS 已自带）
+* 使用包管理器安装 `zip`，如 `sudo apt install zip`（仅供 WSL 和 Linux；macOS 已自带）
 
 ### 执行脚本
 
 * WSL: `cd` 进 script 目录后，执行 `./build_fonts.sh wsl <最大并行数>`
+* Linux: `cd` 进 script 目录后，执行 `./build_fonts.sh linux <最大并行数>`
 * macOS: `cd` 进 script 目录后，执行 `./build_fonts.sh mac <最大并行数>`
 * 其中，**最大并行数**决定最多并行处理的字体数量。每个字体占用约 1.5 CPU 线程和最多 1.5 GB 内存，请根据自己的电脑配置酌情选择。譬如，AMD Ryzen 9 3950X 可将此参数设为 28，在内存足够的情况下，可达 97% CPU 使用率。
 * 脚本运行完成后，最终字体的 ZIP 压缩包将位于根目录下新创建的 release 目录内。运行过程中产生的临时文件将会在结束时自动删除。


### PR DESCRIPTION
* 调整 `build_fonts.sh` 平台检测相关部分，在 Linux 平台上检测 Wine 支持。
* 在 `build_fonts.sh` 中用 shell 脚本实现 `rename`，移除对外部命令 `rename` 的依赖。
  * 在开发者常用的发行版中，RHEL 系、Arch、Gentoo 的 `rename` 都是 [util-linux](https://github.com/karelzak/util-linux) 提供的，与 Debian 系采用的 Perl `rename` 不兼容。